### PR TITLE
Bugfix for Open Source tab

### DIFF
--- a/src/app/open_source/page.tsx
+++ b/src/app/open_source/page.tsx
@@ -30,7 +30,12 @@ export default function Page() {
                     <h1 className='tracking-tight inline font-semibold text-[2.5rem] lg:text-6xl'>
                         Open Source
                     </h1>
-                    <h1 className='tracking-tight inline font-semibold text-[2.1rem] lg:text-5xl bg-clip-text text-transparent bg-gradient-to-b from-[#FF1CF7] to-[#b249f8]'>
+                    <h1
+                        className='tracking-tight inline font-semibold text-[2.1rem] lg:text-5xl bg-clip-text text-transparent bg-gradient-to-b from-[#FF1CF7] to-[#b249f8]'
+                        style={{
+                            paddingBottom: '5px',
+                        }}
+                    >
                         projects that I&apos;ve made
                     </h1>
                     <div className='flex flex-col mt-1 md:mt-5 items-center p-8 md:w-6/12'>
@@ -156,10 +161,10 @@ interface ProjectCardProps {
 }
 
 function ProjectCard({
-    children,
-    title,
-    img,
-}: PropsWithChildren<ProjectCardProps>) {
+                         children,
+                         title,
+                         img,
+                     }: PropsWithChildren<ProjectCardProps>) {
     return (
         <Card className='mt-10 py-4 w-full'>
             <CardHeader className='pb-6 px-4 flex-col items-start'>

--- a/src/app/open_source/page.tsx
+++ b/src/app/open_source/page.tsx
@@ -161,10 +161,10 @@ interface ProjectCardProps {
 }
 
 function ProjectCard({
-                         children,
-                         title,
-                         img,
-                     }: PropsWithChildren<ProjectCardProps>) {
+    children,
+    title,
+    img,
+}: PropsWithChildren<ProjectCardProps>) {
     return (
         <Card className='mt-10 py-4 w-full'>
             <CardHeader className='pb-6 px-4 flex-col items-start'>


### PR DESCRIPTION
In the "Open Source Work" tab, the header appears cut off. It is solved by adding some padding.

![image](https://github.com/KernelFreeze/portfolio/assets/67194268/ec1f0dcd-ef4a-4e76-9795-778442748e94)
